### PR TITLE
Put git repository in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "socket.io-parser",
   "version": "1.0.3",
   "description": "socket.io protocol parser",
+  "repository":{
+    "type": "git",
+    "url": "https://github.com/LearnBoost/socket.io-protocol.git"
+  },
   "dependencies": {
     "debug": "*"
   },


### PR DESCRIPTION
This field is particularly useful for this module, because you can't guess the repository name (socket.io-protocol) from the module name (socket.io-parser). git page will be shown on npmjs.org once its in json.
