### PR TITLE
Added a check for global.Buffer before .isBuffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -230,7 +230,7 @@ exports.decode = function(obj) {
   if ('string' == typeof obj) {
     return decodeString(obj);
   }
-  else if (Buffer.isBuffer(obj) ||
+  else if (global.Buffer && Buffer.isBuffer(obj) ||
           (global.ArrayBuffer && obj instanceof ArrayBuffer) ||
           (global.Blob && obj instanceof Blob)) {
     return decodeBuffer(obj);


### PR DESCRIPTION
Need this check for the future where we remove the browserify insertion
of Buffer. It is also cleaner to check, I believe.
