### PR TITLE
A faster and smaller binary socket.io protocol

### DIFF
--- a/binary.js
+++ b/binary.js
@@ -1,0 +1,142 @@
+/**
+ * Modle requirements
+ */
+
+var isArray = require('isarray');
+
+/**
+ * Replaces every Buffer | ArrayBuffer in packet with a numbered placeholder.
+ * Anything with blobs or files should be fed through removeBlobs before coming
+ * here.
+ *
+ * @param {Object} packet - socket.io event packet
+ * @return {Object} with deconstructed packet and list of buffers
+ * @api public
+ */
+
+exports.deconstructPacket = function(packet) {
+    var buffers = [];
+    var packetData = packet.data;
+
+    function deconstructBinPackRecursive(data) {
+        if (!data) return data;
+
+        if ((global.Buffer && Buffer.isBuffer(data)) ||
+            (global.ArrayBuffer && data instanceof ArrayBuffer)) { // replace binary
+            var placeholder = {_placeholder: true, num: buffers.length};
+            buffers.push(data);
+            return placeholder;
+        } else if (isArray(data)) {
+            var newData = new Array(data.length);
+            for (var i = 0; i < data.length; i++) {
+                newData[i] = deconstructBinPackRecursive(data[i]);
+            }
+            return newData;
+        } else if ('object' == typeof data) {
+            var newData = {};
+            for (var key in data) {
+                newData[key] = deconstructBinPackRecursive(data[key]);
+            }
+            return newData;
+        }
+        return data;
+    }
+
+    var pack = packet;
+    pack.data = deconstructBinPackRecursive(packetData);
+    pack.attachments = buffers.length; // number of binary 'attachments'
+    return {packet: pack, buffers: buffers};
+}
+
+/**
+ * Reconstructs a binary packet from its placeholder packet and buffers
+ *
+ * @param {Object} packet - event packet with placeholders
+ * @param {Array} buffers - binary buffers to put in placeholder positions
+ * @return {Object} reconstructed packet
+ * @api public
+ */
+
+ exports.reconstructPacket = function(packet, buffers) {
+    var curPlaceHolder = 0;
+
+    function reconstructBinPackRecursive(data) {
+        if (data._placeholder) {
+            var buf = buffers[data.num]; // appropriate buffer (should be natural order anyway)
+            return buf;
+        } else if (isArray(data)) {
+            for (var i = 0; i < data.length; i++) {
+                data[i] = reconstructBinPackRecursive(data[i]);
+            }
+            return data;
+        } else if ('object' == typeof data) {
+            for (var key in data) {
+                data[key] = reconstructBinPackRecursive(data[key]);
+            }
+            return data;
+        }
+        return data;
+    }
+
+    packet.data = reconstructBinPackRecursive(packet.data);
+    packet.attachments = undefined; // no longer useful
+    return packet;
+ }
+
+/**
+ * Asynchronously removes Blobs or Files from data via
+ * FileReader's readAsArrayBuffer method. Used before encoding
+ * data as msgpack. Calls callback with the blobless data.
+ *
+ * @param {Object} data
+ * @param {Function} callback
+ * @api private
+ */
+
+exports.removeBlobs = function(data, callback) {
+
+  function removeBlobsRecursive(obj, curKey, containingObject) {
+    if (!obj) return obj;
+
+    // convert any blob
+    if ((global.Blob && obj instanceof Blob) ||
+        (global.File && obj instanceof File)) {
+      pendingBlobs++;
+
+      // async filereader
+      var fileReader = new FileReader();
+      fileReader.onload = function() { // this.result == arraybuffer
+        if (containingObject) {
+          containingObject[curKey] = this.result;
+        }
+        else {
+          bloblessData = this.result;
+        }
+
+        // if nothing pending its callback time
+        if(! --pendingBlobs) {
+          callback(bloblessData);
+        }
+      };
+
+      fileReader.readAsArrayBuffer(obj); // blob -> arraybuffer
+    }
+
+    if (isArray(obj)) { // handle array
+      for (var i = 0; i < obj.length; i++) {
+        removeBlobsRecursive(obj[i], i, obj);
+      }
+    } else if (obj && 'object' == typeof obj) { // and object
+      for (var key in obj) {
+        removeBlobsRecursive(obj[key], key, obj);
+      }
+    }
+  }
+
+  var pendingBlobs = 0;
+  var bloblessData = data;
+  removeBlobsRecursive(bloblessData);
+  if (!pendingBlobs) {
+    callback(bloblessData);
+  }
+}

--- a/index.js
+++ b/index.js
@@ -5,9 +5,8 @@
 
 var debug = require('debug')('socket.io-parser');
 var json = require('json3');
-var msgpack = require('msgpack-js');
 var isArray = require('isarray');
-var base64 = require('base64-js');
+var binary = require('./binary');
 
 
 /**
@@ -82,26 +81,29 @@ exports.ERROR = 4;
  exports.BINARY_EVENT = 5;
 
 /**
- * Encode a packet as a string or buffer, depending on packet type.
+ * Encode a packet as a single string if non-binary, or as a
+ * buffer sequence, depending on packet type.
  *
- * @param {Object} packet
- * @return {String | Buffer} encoded
+ * @param {Object} obj - packet object
+ * @param {Function} callback - function to handle encodings (likely engine.write)
+ * @return Calls callback with Array of encodings
  * @api public
  */
 
 exports.encode = function(obj, callback){
   debug('encoding packet %j', obj);
-  if (obj.type === exports.BINARY_EVENT) {
+
+  if (obj.type == exports.BINARY_EVENT) {
     encodeAsBinary(obj, callback);
   }
   else {
     var encoding = encodeAsString(obj);
-    callback(encoding);
+    callback([encoding]);
   }
 };
 
 /**
- * Encode packet as string (used for anything that is not a binary event).
+ * Encode packet as string.
  *
  * @param {Object} packet
  * @return {String} encoded
@@ -114,6 +116,12 @@ function encodeAsString(obj) {
 
   // first is type
   str += obj.type;
+
+  // attachments if we have them
+  if (exports.BINARY_EVENT == obj.type) {
+    str += obj.attachments;
+    str += '-';
+  }
 
   // if we have a namespace other than `/`
   // we append it followed by a comma `,`
@@ -142,7 +150,9 @@ function encodeAsString(obj) {
 }
 
 /**
- * Encode packet as Buffer (used for binary events).
+ * Encode packet as 'buffer sequence' by removing blobs, and
+ * deconstructing packet into object with placeholders and
+ * a list of buffers.
  *
  * @param {Object} packet
  * @return {Buffer} encoded
@@ -150,78 +160,23 @@ function encodeAsString(obj) {
  */
 
 function encodeAsBinary(obj, callback) {
-  if (global.Blob || global.File) {
-    removeBlobs(obj, callback);
-  } else {
-    var encoding = msgpack.encode(obj);
-    callback(encoding);
+
+  function writeEncoding(bloblessData) {
+    var deconstruction = binary.deconstructPacket(bloblessData);
+    var pack = encodeAsString(deconstruction.packet);
+    var buffers = deconstruction.buffers;
+
+    buffers.unshift(pack); // add packet info to beginning of data list
+    callback(buffers); // write all the buffers
   }
+
+  binary.removeBlobs(obj, writeEncoding);
 }
 
 /**
- * Asynchronously removes Blobs or Files from data via
- * FileReaders readAsArrayBuffer method. Used before encoding
- * data as msgpack. Calls callback with the blobless data.
+ * Decodes an ecoded packet string into packet JSON.
  *
- * @param {Object} data
- * @param {Function} callback
- * @api private
- */
-
-function removeBlobs(data, callback) {
-
-  function removeBlobsRecursive(obj, curKey, containingObject) {
-    if (!obj) return obj;
-
-    // convert any blob
-    if ((global.Blob && obj instanceof Blob) ||
-        (global.File && obj instanceof File)) {
-      pendingBlobs++;
-
-      // async filereader
-      var fileReader = new FileReader();
-      fileReader.onload = function() { // this.result == arraybuffer
-        if (containingObject) {
-          containingObject[curKey] = this.result;
-        }
-        else {
-          bloblessData = this.result;
-        }
-
-        // if nothing pending its callback time
-        if(! --pendingBlobs) {
-          callback(msgpack.encode(bloblessData));
-        }
-      };
-
-      fileReader.readAsArrayBuffer(obj); // blob -> arraybuffer
-    }
-
-    // handle array
-    if (isArray(obj)) {
-      for (var i = 0; i < obj.length; i++) {
-        removeBlobsRecursive(obj[i], i, obj);
-      }
-    } else if (obj && 'object' == typeof obj) { // and object
-      for (var key in obj) {
-        removeBlobsRecursive(obj[key], key, obj);
-      }
-    }
-  }
-
-  var pendingBlobs = 0;
-  var bloblessData = data;
-  removeBlobsRecursive(bloblessData);
-  if (!pendingBlobs) {
-    callback(msgpack.encode(bloblessData));
-  }
-}
-
-/**
- * Decodes a packet Object (msgpack or string) into
- * packet JSON.
- *
- * @param {Object} obj
+ * @param {String} obj - encoded packet
  * @return {Object} packet
  * @api public
  */
@@ -229,14 +184,6 @@ function removeBlobs(data, callback) {
 exports.decode = function(obj) {
   if ('string' == typeof obj) {
     return decodeString(obj);
-  }
-  else if (global.Buffer && Buffer.isBuffer(obj) ||
-          (global.ArrayBuffer && obj instanceof ArrayBuffer) ||
-          (global.Blob && obj instanceof Blob)) {
-    return decodeBuffer(obj);
-  }
-  else if (obj.base64) {
-    return decodeBase64(obj.data);
   }
   else {
     throw new Error('Unknown type: ' + obj);
@@ -258,6 +205,15 @@ function decodeString(str) {
   // look up type
   p.type = Number(str.charAt(0));
   if (null == exports.types[p.type]) return error();
+
+  // look up attachments if type binary
+  if (exports.BINARY_EVENT == p.type) {
+    p.attachments = '';
+    while (str.charAt(++i) != '-') {
+      p.attachments += str.charAt(i);
+    }
+    p.attachments = Number(p.attachments);
+  }
 
   // look up namespace (if any)
   if ('/' == str.charAt(i + 1)) {
@@ -301,72 +257,53 @@ function decodeString(str) {
   return p;
 };
 
-/**
- * Decode binary data packet into JSON packet
- *
- * @param {Buffer | ArrayBuffer | Blob} buf
- * @return {Object} packet
- * @api private
- */
-
-function decodeBuffer(buf) {
-  return msgpack.decode(buf);
-};
+exports.BinaryReconstructor = BinaryReconstructor;
 
 /**
- * Decode base64 msgpack string into a packet
+ * A manager of a binary event's 'buffer sequence'. Should
+ * be constructed whenever a packet of type BINARY_EVENT is
+ * decoded.
  *
- * @param {String} b64
- * @return {Object} packet
- * @api private
+ * @param {Object} packet
+ * @return {BinaryReconstructor} initialized reconstructor
+ * @api public
  */
 
-var NSP_SEP = 163;
-var EVENT_SEP = 146;
-var EVENT_STOP = 216;
+function BinaryReconstructor(packet) {
+  this.reconPack = packet;
+  this.buffers = [];
+}
 
-function decodeBase64(b64) {
-  var packet = {type: exports.BINARY_EVENT};
-  var bytes = base64.toByteArray(b64);
+/**
+ * Method to be called when binary data received from connection
+ * after a BINARY_EVENT packet.
+ *
+ * @param {Buffer | ArrayBuffer} binData - the raw binary data received
+ * @return {null | Object} returns null if more binary data is expected or
+ *   a reconstructed packet object if all buffers have been received.
+ * @api public
+ */
 
-  var nsp = '';
-  var eventName = '';
-  var data = [];
-  var currentThing;
-
-  for (var i = 0; i < bytes.length; i++) {
-    var b = bytes[i];
-    if (!currentThing) {
-      if (b == EVENT_SEP && !eventName) {
-        currentThing = 'ev';
-        i += 1; // skip the next thing which is another seperator
-      }
-    }
-    else if (currentThing == 'nsp') {
-      nsp += String.fromCharCode(b);
-    }
-    else if (currentThing == 'ev') {
-      if (b != EVENT_STOP) {
-        eventName += String.fromCharCode(b);
-      } else {
-        currentThing = 'data';
-        i += 2; // next two bytes are 0 and another seperator
-      }
-    }
-    else if (currentThing == 'data') {
-      if (b != NSP_SEP) {
-        data.push(b);
-      } else {
-        currentThing = 'nsp';
-        i += 4; // next three chars are 'nsp', then another seperator
-      }
-    }
+BinaryReconstructor.prototype.takeBinaryData = function(binData) {
+  this.buffers.push(binData);
+  if (this.buffers.length == this.reconPack.attachments) { // done with buffer list
+    var packet = binary.reconstructPacket(this.reconPack, this.buffers);
+    this.finishedReconstruction();
+    return packet;
   }
+  return null;
+}
 
-  packet.nsp = nsp;
-  packet.data = [eventName, {base64: true, data: base64.fromByteArray(data)}];
-  return packet;
-};
+/**
+ * Cleans up binary packet reconstruction variables.
+ *
+ * @api private
+ */
+
+BinaryReconstructor.prototype.finishedReconstruction = function() {
+  this.reconPack = null;
+  this.buffers = [];
+}
 
 function error(data){
   return {

--- a/package.json
+++ b/package.json
@@ -6,16 +6,10 @@
     "type": "git",
     "url": "https://github.com/LearnBoost/socket.io-protocol.git"
   },
-  "browser": {
-    "msgpack-js": "msgpack-allbrowsers"
-  },
   "dependencies": {
     "debug": "0.7.4",
-    "msgpack-js": "0.3.0",
     "json3": "3.2.6",
-    "isarray": "0.0.1",
-    "base64-js": "0.0.6",
-    "msgpack-allbrowsers": "0.0.1"
+    "isarray": "0.0.1"
   },
   "devDependencies": {
     "mocha": "1.16.2",


### PR DESCRIPTION
This is a squash of 5 commits. Below is a small summary of commits.

Results from it: before the build size of socket.io-client was ~250K. Now it is ~215K.
Tests I was doing here (https://github.com/kevin-roark/socketio-binaryexample/tree/speed-testing) take about 1/4 - 1/5 as long with this commit compared to msgpack.

The first was the initial rewrite of the encoding, which removes msgpack
and instead uses a sequence of engine.write's for a binary event. The
first write is the packet metadata with placeholders in the json for
any binary data. Then the following events are the raw binary data that
get filled by the placeholders.

The second commit was bug fixes that made the tests pass.

The third commit was removing unnecssary packages from package.json.

Fourth commit was adding nice comments, and 5th commit was merging
upstream.
