### PR TITLE
feat: add test `should close the connection if no handshake is received`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -704,6 +704,7 @@ const io = new Server(3000, {
   pingInterval: 300,
   pingTimeout: 200,
   maxPayload: 1000000,
+  connectTimeout: 700,
   cors: {
     origin: "*"
   }

--- a/Readme.md
+++ b/Readme.md
@@ -704,7 +704,7 @@ const io = new Server(3000, {
   pingInterval: 300,
   pingTimeout: 200,
   maxPayload: 1000000,
-  connectTimeout: 700,
+  connectTimeout: 1000,
   cors: {
     origin: "*"
   }

--- a/test-suite/test-suite.js
+++ b/test-suite/test-suite.js
@@ -507,6 +507,15 @@ describe("Socket.IO protocol", () => {
 
       await waitFor(socket, "close");
     });
+
+    
+    it("should close the connection if no handshake is received", async () => {
+      const socket = new WebSocket(
+          `${WS_URL}/socket.io/?EIO=4&transport=websocket`
+      );
+
+      await waitFor(socket, "close");
+    });
   });
 
   describe("disconnect", () => {


### PR DESCRIPTION
According to the [socket.io protocol](https://socket.io/fr/docs/v4/server-options/#connecttimeout), a socket.io server should drop the engine.io connection if the client did not send any handshake before the `connectTimeout` parameter.

It also implies to set a connectTimeout parameter in the test server config that is greater than the `pingInterval + pingTimeout` to avoid other tests to fail.

Currently it is not tested in this test-suite and it would be nice to add it. 